### PR TITLE
Simplify PR Template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -15,10 +15,9 @@ _The commit messages say what you did; this should explain why and/or how._
 
 
 ## Steps to test/reproduce
-_Please explain how to best reproduce the issue and/or test the changes locally and the pages/URLs/views/states in which to review_
+_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
 
 
 
 ## Show me
 _Provide screenshots/animated gifs/videos if necessary._
-

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,5 @@
 ## Cute animal pic
-_Because everyone likes pictures of animals._
+_Because everyone likes pictures of [animals](https://unsplash.com/t/animals)._
 
 
 
@@ -9,31 +9,16 @@ _If this PR relates to a Trello card, don't forget to reference this PR on the c
 
 
 ## Description
-_The commit messages say what you did; this should explain why and how._
+_The commit messages say what you did; this should explain why and/or how._
 - [ ] Description is in Trello card
 
 
 
 ## Steps to test/reproduce
-_Please explain how to best reproduce the issue and/or test the changes locally._
-
-
-
-## Impacted areas of website
-_Provide URLs and/or a description of where to look._
+_Please explain how to best reproduce the issue and/or test the changes locally and the pages/URLs/views/states in which to review_
 
 
 
 ## Show me
 _Provide screenshots/animated gifs/videos if necessary._
 
-
-
----
-
-## Reviewer tasks:
-
-- [ ] Pulled branch and ran code locally (or viewed on preview deployment, if applicable)
-- [ ] Reproduced the issue to review in the browser
-- [ ] Reviewed code
-- [ ] Updated Trello card (if applicable)


### PR DESCRIPTION
Removed Reviewer section and combined the "Steps to test/reproduce" with the "Impacted areas of website" sections.

## Cute animal pic
_Because everyone likes pictures of animals._

![nicolas-savignat-LHavsTWduqI-unsplash](https://user-images.githubusercontent.com/1581694/85333173-bf90ed00-b49e-11ea-92ae-45e4d6a33019.jpg)


## Link to Trello card (if applicable)
_If this PR relates to a Trello card, don't forget to reference this PR on the card as well._

This was just mentioned in Retreat, no Trello card to my knowledge.

## Description
_The commit messages say what you did; this should explain why and how._
We wanted to remove unused PR Template items to make it easier to fill out.



## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally._

Create a new PR? I'm not sure.

## Impacted areas of website
_Provide URLs and/or a description of where to look._

No areas on site. 


## Show me
_Provide screenshots/animated gifs/videos if necessary._

Ironically, this PR didn't give me the new PR template to use.